### PR TITLE
🔄 [MOD] (gpx-parse) Handle gpx version in xmlns header

### DIFF
--- a/lib/gpx-parse.js
+++ b/lib/gpx-parse.js
@@ -156,7 +156,8 @@ exports.parseGpx = function(gpxString, callback) {
 
 	var parseString = require('xml2js').parseString,
 		gpxResult = null,
-		version = null;
+		version = null,
+    xmlnsVersion = null;
 
 	parseString(gpxString, function(error, data) {
 		if (error) {
@@ -168,16 +169,14 @@ exports.parseGpx = function(gpxString, callback) {
       if (!data.gpx) return callback(new Error("version not specified"), null);
 
     	version = data.gpx.$.version;
+      xmlnsVersion = data.gpx.$.xmlns;
 
-      switch (version) {
-        case "1.0":
-          gpxResult = _ParseV10(data.gpx);
-          break;
-        case "1.1":
-          gpxResult = _ParseV11(data.gpx);
-          break;
-        default:
-          return callback(new Error("version not supported"), null);
+      if (version === "1.0" || xmlnsVersion === "http://www.topografix.com/GPX/1/0") {
+        gpxResult = _ParseV10(data.gpx);
+      } else if (version === "1.1" || xmlnsVersion === "http://www.topografix.com/GPX/1/1") {
+        gpxResult = _ParseV11(data.gpx);
+      } else {
+        return callback(new Error("version not supported"), null);
       }
 
       callback(null, gpxResult);


### PR DESCRIPTION
### Main changes
- [X] Handle GPX file with version specified in `xmlns` header

### Notes
- Should fix this issue https://app.raygun.com/crashreporting/1eqz79q/errors/3619035279
- When a user is formatting his GPX file using this tool: https://gotoes.org/strava/Combine_GPX_TCX_FIT_Files.php , the version specified in the file is the tool version and not the GPX version, therefore we can verify the GPX version by checking the `xmlns` header